### PR TITLE
Add Flathub badge to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The build script automatically:
 
 ### From Flathub
 
-[![Get it on Flathub](https://flathub.org/_next/image?url=%2Fapi%2Fbadge%3Flocale%3Den&w=640&q=75)](https://flathub.org/en/apps/io.github.tobagin.scramble)
+[![Get it on Flathub](https://flathub.org/api/badge)](https://flathub.org/en/apps/io.github.tobagin.scramble)
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The build script automatically:
 
 ### From Flathub
 
-*Coming soon - application will be available on Flathub after initial release*
+[![Get it on Flathub](https://flathub.org/_next/image?url=%2Fapi%2Fbadge%3Flocale%3Den&w=640&q=75)](https://flathub.org/en/apps/io.github.tobagin.scramble)
 
 ## Usage
 


### PR DESCRIPTION
Fixes https://github.com/tobagin/scramble/issues/1

(Yo closed it, but the text was still outdated.)

Badge is from https://flathub.org/en/badges

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a “Get it on Flathub” badge to the README, giving users a one-click link to install the app from Flathub and improving discoverability.
  * Standardized README formatting by ensuring a trailing newline at end of file, improving consistency across documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->