### PR TITLE
Add sqgipkg release packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,125 @@
+name: Release
+
+# Builds Linux AppImages (x86_64 + aarch64) and the Windows installer with
+# sqgipkg, then publishes them as release assets for tags like `v1.0.0`.
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+env:
+  APPIMAGE_EXTRACT_AND_RUN: '1'
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout Scramble
+        uses: actions/checkout@v4
+        with:
+          path: Scramble
+
+      - name: Checkout sqgi (runtime + sqgipkg)
+        uses: actions/checkout@v4
+        with:
+          repository: supercamel/sqgi
+          path: sqgi
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential cmake ninja-build pkg-config git file ca-certificates wget \
+            meson valac gettext gobject-introspection blueprint-compiler \
+            libglib2.0-dev libgirepository1.0-dev libffi-dev libcairo2-dev \
+            libgtk-4-dev libadwaita-1-dev libgdk-pixbuf-2.0-dev libgexiv2-dev \
+            gir1.2-gtk-4.0 gir1.2-adw-1 gir1.2-gexiv2-0.10 \
+            desktop-file-utils appstream-util libxml2-utils \
+            gcc-aarch64-linux-gnu g++-aarch64-linux-gnu qemu-user-static binfmt-support \
+            mingw-w64 nsis squashfs-tools libfuse2t64
+
+      - name: Build and install sqgi
+        run: |
+          cmake -S sqgi -B sqgi/build -G Ninja -DCMAKE_BUILD_TYPE=Release -DSQ_ENABLE_JIT=ON
+          cmake --build sqgi/build
+          sudo cmake --install sqgi/build --prefix /usr/local
+          sudo ldconfig
+
+      - name: Build Linux x86_64 AppImage
+        working-directory: Scramble
+        run: |
+          set +e
+          "$GITHUB_WORKSPACE/sqgi/build/sqgi" "$GITHUB_WORKSPACE/sqgi/tools/sqgipkg" \
+            --target appimage --appimage-arch x86_64 --sqgi-source-dir "$GITHUB_WORKSPACE/sqgi" \
+            2>&1 | tee sqgipkg-x86_64.log
+          status=${PIPESTATUS[0]}
+          set -e
+          if [ "$status" -ne 0 ]; then
+            msg="$(tail -n 80 sqgipkg-x86_64.log | python3 -c 'import sys; print(sys.stdin.read()[-3000:].replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A"))')"
+            echo "::error title=sqgipkg x86_64 failed::$msg"
+            exit "$status"
+          fi
+
+      - name: Build Linux aarch64 AppImage
+        working-directory: Scramble
+        run: |
+          set +e
+          "$GITHUB_WORKSPACE/sqgi/build/sqgi" "$GITHUB_WORKSPACE/sqgi/tools/sqgipkg" \
+            --target appimage --appimage-arch aarch64 --sqgi-source-dir "$GITHUB_WORKSPACE/sqgi" \
+            2>&1 | tee sqgipkg-aarch64.log
+          status=${PIPESTATUS[0]}
+          set -e
+          if [ "$status" -ne 0 ]; then
+            msg="$(tail -n 80 sqgipkg-aarch64.log | python3 -c 'import sys; print(sys.stdin.read()[-3000:].replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A"))')"
+            echo "::error title=sqgipkg aarch64 failed::$msg"
+            exit "$status"
+          fi
+
+      - name: Build Windows installer
+        working-directory: Scramble
+        run: |
+          set +e
+          "$GITHUB_WORKSPACE/sqgi/build/sqgi" "$GITHUB_WORKSPACE/sqgi/tools/sqgipkg" \
+            --target win-nsis --sqgi-source-dir "$GITHUB_WORKSPACE/sqgi" \
+            2>&1 | tee sqgipkg-windows.log
+          status=${PIPESTATUS[0]}
+          set -e
+          if [ "$status" -ne 0 ]; then
+            msg="$(tail -n 80 sqgipkg-windows.log | python3 -c 'import sys; print(sys.stdin.read()[-3000:].replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A"))')"
+            echo "::error title=sqgipkg Windows failed::$msg"
+            exit "$status"
+          fi
+
+      - name: Collect artifacts
+        working-directory: Scramble
+        run: |
+          mkdir -p artifacts
+          cp dist-linux-x86_64/Scramble.AppImage artifacts/Scramble-x86_64.AppImage
+          cp dist-linux-aarch64/Scramble.AppImage artifacts/Scramble-aarch64.AppImage
+          cp dist-windows-x86_64/Scramble-Setup.exe artifacts/Scramble-Setup.exe
+          ls -lh artifacts
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: scramble-builds
+          path: Scramble/artifacts/*
+
+      - name: Publish release assets
+        if: startsWith(github.ref, 'refs/tags/')
+        working-directory: Scramble
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" artifacts/* \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "$GITHUB_REF_NAME" \
+            --generate-notes \
+          || gh release upload "$GITHUB_REF_NAME" artifacts/* \
+            --repo "$GITHUB_REPOSITORY" --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: supercamel/sqgi
+          ref: v0.1.2-alpha
           path: sqgi
 
       - name: Install build dependencies
@@ -40,7 +41,7 @@ jobs:
             libglib2.0-dev libgirepository1.0-dev libffi-dev libcairo2-dev \
             libgtk-4-dev libadwaita-1-dev libgdk-pixbuf-2.0-dev libgexiv2-dev \
             gir1.2-gtk-4.0 gir1.2-adw-1 gir1.2-gexiv2-0.10 \
-            desktop-file-utils appstream-util libxml2-utils \
+            desktop-file-utils appstream libxml2-utils \
             gcc-aarch64-linux-gnu g++-aarch64-linux-gnu qemu-user-static binfmt-support \
             mingw-w64 nsis squashfs-tools libfuse2t64
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 build/
 _build/
 .builddir/
+dist-*/
+.sqgipkg/
 meson-logs/
 meson-private/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### 🔧 Changed
+
+- **Release packaging**: Added sqgipkg packaging for Linux x86_64/aarch64 AppImages and a Windows NSIS installer.
+
 ## [1.4.4] - 2026-06-03
 
 ### 🔧 Changed

--- a/data/ui/dialogs/shortcuts_window.blp
+++ b/data/ui/dialogs/shortcuts_window.blp
@@ -1,57 +1,62 @@
 using Gtk 4.0;
-using Adw 1;
 
-Adw.ShortcutsDialog shortcuts_window {
-  Adw.ShortcutsSection {
-    title: _("Image Operations");
+Gtk.ShortcutsWindow shortcuts_window {
+  modal: true;
 
-    Adw.ShortcutsItem {
-      title: _("Open Image");
-      action-name: "win.open";
+  Gtk.ShortcutsSection {
+    section-name: "shortcuts";
+
+    Gtk.ShortcutsGroup {
+      title: _("Image Operations");
+
+      Gtk.ShortcutsShortcut {
+        title: _("Open Image");
+        action-name: "win.open";
+      }
+
+      Gtk.ShortcutsShortcut {
+        title: _("Save Clean Copy");
+        action-name: "win.save";
+      }
+
+      Gtk.ShortcutsShortcut {
+        title: _("Clear Image");
+        action-name: "win.clear";
+      }
+
+      Gtk.ShortcutsShortcut {
+        title: _("Compare Before/After");
+        action-name: "win.compare";
+      }
+
+      Gtk.ShortcutsShortcut {
+        title: _("Batch Process");
+        action-name: "win.batch-process";
+      }
+
+      Gtk.ShortcutsShortcut {
+        title: _("Export Metadata");
+        action-name: "win.export-metadata";
+      }
     }
 
-    Adw.ShortcutsItem {
-      title: _("Save Clean Copy");
-      action-name: "win.save";
-    }
+    Gtk.ShortcutsGroup {
+      title: _("Application");
 
-    Adw.ShortcutsItem {
-      title: _("Clear Image");
-      action-name: "win.clear";
-    }
+      Gtk.ShortcutsShortcut {
+        title: _("Preferences");
+        action-name: "app.preferences";
+      }
 
-    Adw.ShortcutsItem {
-      title: _("Compare Before/After");
-      action-name: "win.compare";
-    }
+      Gtk.ShortcutsShortcut {
+        title: _("Keyboard Shortcuts");
+        action-name: "win.show-shortcuts";
+      }
 
-    Adw.ShortcutsItem {
-      title: _("Batch Process");
-      action-name: "win.batch-process";
-    }
-
-    Adw.ShortcutsItem {
-      title: _("Export Metadata");
-      action-name: "win.export-metadata";
-    }
-  }
-
-  Adw.ShortcutsSection {
-    title: _("Application");
-
-    Adw.ShortcutsItem {
-      title: _("Preferences");
-      action-name: "app.preferences";
-    }
-
-    Adw.ShortcutsItem {
-      title: _("Keyboard Shortcuts");
-      action-name: "win.show-shortcuts";
-    }
-
-    Adw.ShortcutsItem {
-      title: _("Quit");
-      action-name: "app.quit";
+      Gtk.ShortcutsShortcut {
+        title: _("Quit");
+        action-name: "app.quit";
+      }
     }
   }
 }

--- a/meson.build
+++ b/meson.build
@@ -39,7 +39,7 @@ gio_dep = dependency('gio-2.0')
 gtk_dep = dependency('gtk4')
 adw_dep = dependency('libadwaita-1')
 gdkpixbuf_dep = dependency('gdk-pixbuf-2.0')
-gexiv2_dep = dependency('gexiv2-0.16', required: true)
+gexiv2_dep = dependency('gexiv2', required: true)
 
 # Blueprint compiler
 blueprint_compiler = find_program('blueprint-compiler', required: true)

--- a/sqgipkg.json
+++ b/sqgipkg.json
@@ -1,0 +1,171 @@
+{
+  "name": "Scramble",
+  "entry": {
+    "type": "native",
+    "linux": "build-linux-x86_64/src/scramble",
+    "windows": "build-windows-x86_64/src/scramble.exe"
+  },
+  "linux": {
+    "arches": [
+      {
+        "arch": "x86_64",
+        "build_dir": "build-linux-x86_64",
+        "entry_linux": "build-linux-x86_64/src/scramble",
+        "deb": {
+          "download": true,
+          "packages": [
+            "libgtk-4-dev",
+            "gir1.2-gtk-4.0",
+            "libadwaita-1-dev",
+            "gir1.2-adw-1",
+            "libgexiv2-dev",
+            "gir1.2-gexiv2-0.10",
+            "libglib2.0-dev",
+            "libgdk-pixbuf-2.0-dev",
+            "gobject-introspection",
+            "libgirepository1.0-dev",
+            "adwaita-icon-theme",
+            "hicolor-icon-theme",
+            "librsvg2-common"
+          ]
+        },
+        "inherit_native_projects": false,
+        "native_projects": [
+          {
+            "name": "scramble",
+            "dir": ".",
+            "build": [
+              "VALAFLAGS=\"--vapidir=$SQGI_LINUX_SYSROOT/usr/share/vala/vapi --girdir=$SQGI_LINUX_SYSROOT/usr/share/gir-1.0 $VALAFLAGS\" PKG_CONFIG_SYSROOT_DIR=\"$SQGI_LINUX_SYSROOT\" PKG_CONFIG_LIBDIR=\"$SQGI_LINUX_SYSROOT/usr/lib/$SQGI_LINUX_TRIPLET/pkgconfig:$SQGI_LINUX_SYSROOT/usr/share/pkgconfig\" meson setup \"$SQGI_LINUX_BUILD_DIR\" --wipe --prefix /usr --buildtype=release ${SQGI_LINUX_MESON_CROSS_FILE:+--cross-file \"$SQGI_LINUX_MESON_CROSS_FILE\"} || VALAFLAGS=\"--vapidir=$SQGI_LINUX_SYSROOT/usr/share/vala/vapi --girdir=$SQGI_LINUX_SYSROOT/usr/share/gir-1.0 $VALAFLAGS\" PKG_CONFIG_SYSROOT_DIR=\"$SQGI_LINUX_SYSROOT\" PKG_CONFIG_LIBDIR=\"$SQGI_LINUX_SYSROOT/usr/lib/$SQGI_LINUX_TRIPLET/pkgconfig:$SQGI_LINUX_SYSROOT/usr/share/pkgconfig\" meson setup \"$SQGI_LINUX_BUILD_DIR\" --prefix /usr --buildtype=release ${SQGI_LINUX_MESON_CROSS_FILE:+--cross-file \"$SQGI_LINUX_MESON_CROSS_FILE\"}",
+              "meson compile -C \"$SQGI_LINUX_BUILD_DIR\""
+            ],
+            "files": [
+              {
+                "path": "build-linux-x86_64/data/io.github.tobagin.scramble.gschema.xml",
+                "dest": "usr/share/glib-2.0/schemas/io.github.tobagin.scramble.gschema.xml"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "arch": "aarch64",
+        "build_dir": "build-linux-aarch64",
+        "entry_linux": "build-linux-aarch64/src/scramble",
+        "deb": {
+          "download": true,
+          "packages": [
+            "libgtk-4-dev",
+            "gir1.2-gtk-4.0",
+            "libadwaita-1-dev",
+            "gir1.2-adw-1",
+            "libgexiv2-dev",
+            "gir1.2-gexiv2-0.10",
+            "libglib2.0-dev",
+            "libgdk-pixbuf-2.0-dev",
+            "gobject-introspection",
+            "libgirepository1.0-dev",
+            "adwaita-icon-theme",
+            "hicolor-icon-theme",
+            "librsvg2-common"
+          ]
+        },
+        "inherit_native_projects": false,
+        "native_projects": [
+          {
+            "name": "scramble",
+            "dir": ".",
+            "build": [
+              "VALAFLAGS=\"--vapidir=$SQGI_LINUX_SYSROOT/usr/share/vala/vapi --girdir=$SQGI_LINUX_SYSROOT/usr/share/gir-1.0 $VALAFLAGS\" PKG_CONFIG_SYSROOT_DIR=\"$SQGI_LINUX_SYSROOT\" PKG_CONFIG_LIBDIR=\"$SQGI_LINUX_SYSROOT/usr/lib/$SQGI_LINUX_TRIPLET/pkgconfig:$SQGI_LINUX_SYSROOT/usr/share/pkgconfig\" meson setup \"$SQGI_LINUX_BUILD_DIR\" --wipe --prefix /usr --buildtype=release ${SQGI_LINUX_MESON_CROSS_FILE:+--cross-file \"$SQGI_LINUX_MESON_CROSS_FILE\"} || VALAFLAGS=\"--vapidir=$SQGI_LINUX_SYSROOT/usr/share/vala/vapi --girdir=$SQGI_LINUX_SYSROOT/usr/share/gir-1.0 $VALAFLAGS\" PKG_CONFIG_SYSROOT_DIR=\"$SQGI_LINUX_SYSROOT\" PKG_CONFIG_LIBDIR=\"$SQGI_LINUX_SYSROOT/usr/lib/$SQGI_LINUX_TRIPLET/pkgconfig:$SQGI_LINUX_SYSROOT/usr/share/pkgconfig\" meson setup \"$SQGI_LINUX_BUILD_DIR\" --prefix /usr --buildtype=release ${SQGI_LINUX_MESON_CROSS_FILE:+--cross-file \"$SQGI_LINUX_MESON_CROSS_FILE\"}",
+              "meson compile -C \"$SQGI_LINUX_BUILD_DIR\""
+            ],
+            "files": [
+              {
+                "path": "build-linux-aarch64/data/io.github.tobagin.scramble.gschema.xml",
+                "dest": "usr/share/glib-2.0/schemas/io.github.tobagin.scramble.gschema.xml"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "windows": {
+    "msys2_prefix": "mingw64",
+    "gdk_backend": "win32",
+    "console": false,
+    "build_dir": "build-windows-x86_64",
+    "packages": [
+      "mingw-w64-x86_64-vala",
+      "mingw-w64-x86_64-gtk4",
+      "mingw-w64-x86_64-libadwaita",
+      "mingw-w64-x86_64-gdk-pixbuf2",
+      "mingw-w64-x86_64-hicolor-icon-theme",
+      "mingw-w64-x86_64-adwaita-icon-theme",
+      "mingw-w64-x86_64-adwaita-icon-theme-legacy",
+      "mingw-w64-x86_64-librsvg",
+      "mingw-w64-x86_64-libinih"
+    ],
+    "native_dependencies": [
+      {
+        "name": "exiv2",
+        "repo": "https://github.com/Exiv2/exiv2.git",
+        "dir": ".sqgipkg/native/exiv2",
+        "ref": "v0.28.8",
+        "update": true,
+        "shallow": false,
+        "build": [
+          "cmake -E rm -rf build-windows-x86_64",
+          "cmake -S . -B build-windows-x86_64 -G Ninja -DCMAKE_TOOLCHAIN_FILE=\"$SQGI_WIN_CMAKE_TOOLCHAIN\" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=\"$SQGI_WINDOWS_PREFIX\" -DEXIV2_ENABLE_NLS=ON -DEXIV2_BUILD_SAMPLES=OFF -DEXIV2_BUILD_EXIV2_COMMAND=OFF -DEXIV2_ENABLE_BMFF=ON -DCMAKE_CXX_FLAGS=-Wno-format",
+          "cmake --build build-windows-x86_64"
+        ],
+        "install": [
+          "DESTDIR=\"$SQGI_WINDOWS_SYSROOT\" cmake --install build-windows-x86_64 --prefix \"$SQGI_WINDOWS_PREFIX\""
+        ],
+        "stage": false
+      },
+      {
+        "name": "gexiv2",
+        "repo": "https://gitlab.gnome.org/GNOME/gexiv2.git",
+        "dir": ".sqgipkg/native/gexiv2",
+        "ref": "gexiv2-0.14.6",
+        "update": true,
+        "shallow": false,
+        "build": [
+          "sed -i '/^glib-compile-resources = /d;/^glib-compile-schemas = /d;/^glib-mkenums = /d;/^glib-genmarshal = /d' \"$SQGI_MESON_CROSS_FILE\" && sed -i \"/^\\[binaries\\]/a glib-compile-resources = '/usr/bin/glib-compile-resources'\\nglib-compile-schemas = '/usr/bin/glib-compile-schemas'\\nglib-mkenums = '/usr/bin/glib-mkenums'\\nglib-genmarshal = '/usr/bin/glib-genmarshal'\" \"$SQGI_MESON_CROSS_FILE\"",
+          "meson setup build-windows-x86_64 --wipe --prefix \"$SQGI_WINDOWS_PREFIX\" --buildtype=release --cross-file \"$SQGI_MESON_CROSS_FILE\" -Dpython3=false -Dintrospection=false -Dvapi=false || meson setup build-windows-x86_64 --prefix \"$SQGI_WINDOWS_PREFIX\" --buildtype=release --cross-file \"$SQGI_MESON_CROSS_FILE\" -Dpython3=false -Dintrospection=false -Dvapi=false",
+          "meson compile -C build-windows-x86_64"
+        ],
+        "install": [
+          "DESTDIR=\"$SQGI_WINDOWS_SYSROOT\" meson install -C build-windows-x86_64",
+          "install -Dm644 /usr/share/vala/vapi/gexiv2.vapi \"$SQGI_WINDOWS_PREFIX_DIR/share/vala/vapi/gexiv2.vapi\" && install -Dm644 /usr/share/vala/vapi/gexiv2.deps \"$SQGI_WINDOWS_PREFIX_DIR/share/vala/vapi/gexiv2.deps\""
+        ],
+        "stage": false
+      }
+    ],
+    "native_projects": [
+      {
+        "name": "scramble",
+        "dir": ".",
+        "build": [
+          "sed -i '/^glib-compile-resources = /d;/^glib-compile-schemas = /d;/^glib-mkenums = /d;/^glib-genmarshal = /d' \"$SQGI_MESON_CROSS_FILE\" && sed -i \"/^\\[binaries\\]/a glib-compile-resources = '/usr/bin/glib-compile-resources'\\nglib-compile-schemas = '/usr/bin/glib-compile-schemas'\\nglib-mkenums = '/usr/bin/glib-mkenums'\\nglib-genmarshal = '/usr/bin/glib-genmarshal'\" \"$SQGI_MESON_CROSS_FILE\"",
+          "VALAFLAGS=\"--vapidir=$SQGI_WINDOWS_PREFIX_DIR/share/vala/vapi --girdir=$SQGI_WINDOWS_PREFIX_DIR/share/gir-1.0 $VALAFLAGS\" meson setup \"$SQGI_WINDOWS_BUILD_DIR\" --wipe --prefix \"$SQGI_WINDOWS_PREFIX\" --buildtype=release --cross-file \"$SQGI_MESON_CROSS_FILE\" || VALAFLAGS=\"--vapidir=$SQGI_WINDOWS_PREFIX_DIR/share/vala/vapi --girdir=$SQGI_WINDOWS_PREFIX_DIR/share/gir-1.0 $VALAFLAGS\" meson setup \"$SQGI_WINDOWS_BUILD_DIR\" --prefix \"$SQGI_WINDOWS_PREFIX\" --buildtype=release --cross-file \"$SQGI_MESON_CROSS_FILE\"",
+          "meson compile -C \"$SQGI_WINDOWS_BUILD_DIR\""
+        ],
+        "files": [
+          {
+            "path": "build-windows-x86_64/data/io.github.tobagin.scramble.gschema.xml",
+            "dest": "share/glib-2.0/schemas/io.github.tobagin.scramble.gschema.xml"
+          }
+        ]
+      }
+    ],
+    "nsis_options": {
+      "install_dir": "$PROGRAMFILES\\Scramble",
+      "request_execution_level": "admin",
+      "desktop_shortcut": true,
+      "start_menu_shortcut": true,
+      "start_menu_folder": "Scramble",
+      "uninstall_registry": true
+    }
+  }
+}

--- a/sqgipkg.json
+++ b/sqgipkg.json
@@ -12,6 +12,7 @@
         "build_dir": "build-linux-x86_64",
         "entry_linux": "build-linux-x86_64/src/scramble",
         "deb": {
+          "suite": "noble",
           "download": true,
           "packages": [
             "libgtk-4-dev",
@@ -39,10 +40,15 @@
               "meson compile -C \"$SQGI_LINUX_BUILD_DIR\""
             ],
             "files": [
-              {
-                "path": "build-linux-x86_64/data/io.github.tobagin.scramble.gschema.xml",
-                "dest": "usr/share/glib-2.0/schemas/io.github.tobagin.scramble.gschema.xml"
-              }
+              "build-linux-x86_64/data/io.github.tobagin.scramble.gschema.xml=usr/share/glib-2.0/schemas/io.github.tobagin.scramble.gschema.xml",
+              "build-linux-x86_64/po/en/LC_MESSAGES/scramble.mo=usr/share/locale/en/LC_MESSAGES/scramble.mo",
+              "build-linux-x86_64/po/es/LC_MESSAGES/scramble.mo=usr/share/locale/es/LC_MESSAGES/scramble.mo",
+              "build-linux-x86_64/po/fr/LC_MESSAGES/scramble.mo=usr/share/locale/fr/LC_MESSAGES/scramble.mo",
+              "build-linux-x86_64/po/de/LC_MESSAGES/scramble.mo=usr/share/locale/de/LC_MESSAGES/scramble.mo",
+              "build-linux-x86_64/po/pt/LC_MESSAGES/scramble.mo=usr/share/locale/pt/LC_MESSAGES/scramble.mo",
+              "build-linux-x86_64/data/io.github.tobagin.scramble.desktop=usr/share/applications/io.github.tobagin.scramble.desktop",
+              "build-linux-x86_64/data/io.github.tobagin.scramble.metainfo.xml=usr/share/metainfo/io.github.tobagin.scramble.metainfo.xml",
+              "data/icons/hicolor/scalable/apps/io.github.tobagin.scramble.svg=usr/share/icons/hicolor/scalable/apps/io.github.tobagin.scramble.svg"
             ]
           }
         ]
@@ -52,6 +58,7 @@
         "build_dir": "build-linux-aarch64",
         "entry_linux": "build-linux-aarch64/src/scramble",
         "deb": {
+          "suite": "noble",
           "download": true,
           "packages": [
             "libgtk-4-dev",
@@ -79,10 +86,15 @@
               "meson compile -C \"$SQGI_LINUX_BUILD_DIR\""
             ],
             "files": [
-              {
-                "path": "build-linux-aarch64/data/io.github.tobagin.scramble.gschema.xml",
-                "dest": "usr/share/glib-2.0/schemas/io.github.tobagin.scramble.gschema.xml"
-              }
+              "build-linux-aarch64/data/io.github.tobagin.scramble.gschema.xml=usr/share/glib-2.0/schemas/io.github.tobagin.scramble.gschema.xml",
+              "build-linux-aarch64/po/en/LC_MESSAGES/scramble.mo=usr/share/locale/en/LC_MESSAGES/scramble.mo",
+              "build-linux-aarch64/po/es/LC_MESSAGES/scramble.mo=usr/share/locale/es/LC_MESSAGES/scramble.mo",
+              "build-linux-aarch64/po/fr/LC_MESSAGES/scramble.mo=usr/share/locale/fr/LC_MESSAGES/scramble.mo",
+              "build-linux-aarch64/po/de/LC_MESSAGES/scramble.mo=usr/share/locale/de/LC_MESSAGES/scramble.mo",
+              "build-linux-aarch64/po/pt/LC_MESSAGES/scramble.mo=usr/share/locale/pt/LC_MESSAGES/scramble.mo",
+              "build-linux-aarch64/data/io.github.tobagin.scramble.desktop=usr/share/applications/io.github.tobagin.scramble.desktop",
+              "build-linux-aarch64/data/io.github.tobagin.scramble.metainfo.xml=usr/share/metainfo/io.github.tobagin.scramble.metainfo.xml",
+              "data/icons/hicolor/scalable/apps/io.github.tobagin.scramble.svg=usr/share/icons/hicolor/scalable/apps/io.github.tobagin.scramble.svg"
             ]
           }
         ]
@@ -152,10 +164,13 @@
           "meson compile -C \"$SQGI_WINDOWS_BUILD_DIR\""
         ],
         "files": [
-          {
-            "path": "build-windows-x86_64/data/io.github.tobagin.scramble.gschema.xml",
-            "dest": "share/glib-2.0/schemas/io.github.tobagin.scramble.gschema.xml"
-          }
+          "build-windows-x86_64/data/io.github.tobagin.scramble.gschema.xml=share/glib-2.0/schemas/io.github.tobagin.scramble.gschema.xml",
+          "build-windows-x86_64/po/en/LC_MESSAGES/scramble.mo=share/locale/en/LC_MESSAGES/scramble.mo",
+          "build-windows-x86_64/po/es/LC_MESSAGES/scramble.mo=share/locale/es/LC_MESSAGES/scramble.mo",
+          "build-windows-x86_64/po/fr/LC_MESSAGES/scramble.mo=share/locale/fr/LC_MESSAGES/scramble.mo",
+          "build-windows-x86_64/po/de/LC_MESSAGES/scramble.mo=share/locale/de/LC_MESSAGES/scramble.mo",
+          "build-windows-x86_64/po/pt/LC_MESSAGES/scramble.mo=share/locale/pt/LC_MESSAGES/scramble.mo",
+          "data/icons/hicolor/scalable/apps/io.github.tobagin.scramble.svg=share/icons/hicolor/scalable/apps/io.github.tobagin.scramble.svg"
         ]
       }
     ],

--- a/src/dialogs/ShortcutsWindow.vala
+++ b/src/dialogs/ShortcutsWindow.vala
@@ -16,9 +16,10 @@ namespace Scramble {
 #else
                 builder.add_from_resource("/io/github/tobagin/scramble/shortcuts_window.ui");
 #endif
-                var shortcuts_dialog = builder.get_object("shortcuts_window") as Adw.ShortcutsDialog;
+                var shortcuts_dialog = builder.get_object("shortcuts_window") as Gtk.ShortcutsWindow;
                 if (shortcuts_dialog != null) {
-                    shortcuts_dialog.present(parent);
+                    shortcuts_dialog.set_transient_for(parent);
+                    shortcuts_dialog.present();
                 }
             } catch (Error e) {
                 warning("Failed to load shortcuts dialog: %s", e.message);


### PR DESCRIPTION
This PR adds optional `sqgipkg` packaging for Scramble.

The idea is to make release artifacts easier to produce while leaving the existing Meson/Flatpak workflow intact.

With the added `sqgipkg.json` manifest and GitHub Actions workflow, release tags can build:

* Linux x86_64 AppImage
* Linux aarch64 AppImage
* Windows x86_64 NSIS installer

The workflow only runs on version tag pushes or manual dispatch, so normal development pushes are not affected.

**Release flow**

If you choose to use this workflow for releases, it can be triggered with a version tag, for example:

```sh
git tag v1.4.5
git push origin v1.4.5
```

The workflow will then build the AppImages and Windows installer and attach them to the GitHub release.

**Notes**

The Windows build uses the MinGW/MSYS2 target. Since Scramble depends on GExiv2, the packaging manifest builds Exiv2/GExiv2 as native dependencies and bundles the required DLLs into the installer.

I also made a small compatibility adjustment to the shortcuts dialog, switching it to `Gtk.ShortcutsWindow` so the project builds cleanly against the Ubuntu Noble GTK/libadwaita stack used by the packaging workflow.

The Windows package will look tidier with an icon. If you choose to bundle a .ico icon later, you can add 
```
"icon": "path/to/icon.ico",
```
to the Windows NSIS options in the sqgipkg.json manifest. 

**Testing**

I ran `sqgipkg --target all` locally and verified that the expected artifacts were generated:

* `dist-linux-x86_64/Scramble.AppImage`
* `dist-linux-aarch64/Scramble.AppImage`
* `dist-windows-x86_64/Scramble-Setup.exe`

I also ran the full GitHub Actions workflow, downloaded the generated artifacts, and tested:

* Linux x86_64 AppImage
* Windows x86_64 installer

Both ran successfully.

I have not yet tested the aarch64 AppImage on hardware. Since it is built through the same packaging path as the x86_64 AppImage, I expect it to be low risk, but I’ll verify it separately.

Happy to adjust the packaging setup if you’d prefer it done another way.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prebuilt Linux AppImage packages for x86_64 and aarch64
  * Windows installer support (NSIS)
  * Shortcuts window migrated to a modal shortcuts window

* **Chores**
  * Added automated GitHub release workflow to build and publish artifacts
  * Added packaging configuration for cross-platform builds
  * Updated ignore list and changelog; adjusted build dependency reference
<!-- end of auto-generated comment: release notes by coderabbit.ai -->